### PR TITLE
Add setup.py script to build Python module independently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Makefile.in
 # Project specific
 /templatetags
 /template_*.sed
+/python/MANIFEST

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.pyx
+include *.pxd

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import sys, os
+from distutils.core import setup
+from distutils.extension import Extension
+
+try:
+    from Cython.Build import cythonize
+    HAVE_CYTHON = True
+except ImportError:
+    HAVE_CYTHON = False
+
+# Determine usage of Cython
+USE_CYTHON = HAVE_CYTHON
+if 'USE_CYTHON' in os.environ:
+    USE_CYTHON = os.environ['USE_CYTHON'].lower() in ('1', 'yes')
+
+if USE_CYTHON and not HAVE_CYTHON:
+    sys.stderr.write('Cython was not found!\n')
+    sys.exit(-1)
+
+# Add include dirs specified by environment variables
+include_dirs = []
+if 'GMP_INCLUDE_DIR' in os.environ:
+    include_dirs.append(os.environ['GMP_INCLUDE_DIR'])
+if 'QSOPTEX_INCLUDE_DIR' in os.environ:
+    include_dirs.append(os.environ['QSOPTEX_INCLUDE_DIR'])
+
+# Add library dirs specified by environment variables
+library_dirs = []
+if 'GMP_LIBRARY_DIR' in os.environ:
+    library_dirs.append(os.environ['GMP_LIBRARY_DIR'])
+if 'QSOPTEX_LIBRARY_DIR' in os.environ:
+    library_dirs.append(os.environ['QSOPTEX_LIBRARY_DIR'])
+
+ext = '.pyx' if USE_CYTHON else '.c'
+extensions = [Extension("qsoptex", ["qsoptex"+ext],
+                include_dirs=include_dirs,
+                libraries=['gmp', 'qsopt_ex'],
+                library_dirs=library_dirs)]
+
+if USE_CYTHON:
+    extensions = cythonize(extensions, include_path=include_dirs)
+
+setup(
+    name='pyqsoptex',
+    version='2.5.10.1',
+    license='GPLv3+',
+    url='https://github.com/jonls/qsopt-ex',
+    author='Jon Lund Steffensen',
+    author_email='jonlst@gmail.com',
+
+    ext_modules = extensions
+)


### PR DESCRIPTION
The setup.py script is based on distutils. When building the module
using the autotools build system, the module will depend on the
simultaneously built libqsopt_ex. This build script can be used
to build and install the Python module based on the libqsopt_ex
that is already installed on the system. This makes building and
packaging easier in some cases, particularly when packaging for
various distributions.
