### PR TITLE
Fix #2: Infinite loop when no constraints defined

### DIFF
--- a/qsopt_ex/qsopt.c
+++ b/qsopt_ex/qsopt.c
@@ -776,6 +776,9 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE EGLPNUM_TYPENAME_QSdata *EGLPNUM_TYPENAME_QScop
 		CHECKRVALG (rval, CLEANUP);
 		ILL_UTIL_STR (p2->qslp->objname, buf);
 	}
+	if (p2->qslp->rowtab.tablesize == 0) {
+		ILLsymboltab_create(&p2->qslp->rowtab, 100);
+	}
 	rval = ILLsymboltab_register (&p2->qslp->rowtab, p2->qslp->objname,
 																-1, &pindex, &hit);
 	rval = rval || hit;

--- a/qsopt_ex/simplex.c
+++ b/qsopt_ex/simplex.c
@@ -824,6 +824,9 @@ int EGLPNUM_TYPENAME_ILLsimplex (
 	EGLPNUM_TYPENAME_feas_info fi;
 	EGLPNUM_TYPENAME_iter_info it;
 
+	EGLPNUM_TYPENAME_ILLsvector_init (&wz);
+	EGLPNUM_TYPENAME_ILLsvector_init (&updz);
+
 	EGLPNUM_TYPENAME_EGlpNumInitVar (fi.totinfeas);
 	EGLPNUM_TYPENAME_EGlpNumInitVar (it.prevobj);
 	EGLPNUM_TYPENAME_EGlpNumInitVar (it.objtol);
@@ -861,10 +864,8 @@ int EGLPNUM_TYPENAME_ILLsimplex (
 	rval = EGLPNUM_TYPENAME_build_internal_lpinfo (lp);
 	CHECKRVALG (rval, CLEANUP);
 
-	EGLPNUM_TYPENAME_ILLsvector_init (&wz);
 	rval = EGLPNUM_TYPENAME_ILLsvector_alloc (&wz, lp->nrows);
 	CHECKRVALG (rval, CLEANUP);
-	EGLPNUM_TYPENAME_ILLsvector_init (&updz);
 	rval = EGLPNUM_TYPENAME_ILLsvector_alloc (&updz, lp->nrows);
 	CHECKRVALG (rval, CLEANUP);
 

--- a/tests/test_qs.c
+++ b/tests/test_qs.c
@@ -399,6 +399,52 @@ CLEANUP:
     if (p) mpq_QSfree_prob(p);
 }
 
+static void test_solve_no_constraints(int test_id)
+{
+    mpq_t objective, lower, upper;
+    mpq_init(objective);
+    mpq_init(lower);
+    mpq_init(upper);
+
+    mpq_set_d(objective, 4.0);
+    mpq_set_d(lower, -5.0);
+    mpq_set_d(upper, 75.5);
+
+    mpq_QSprob p = mpq_QScreate_prob("test", QS_MAX);
+    if (p == NULL) {
+        printf("not ok %i - Unable to create LP problem\n", test_id);
+        goto CLEANUP;
+    }
+
+    /* Test create new column. */
+    int rval = mpq_QSnew_col(p, objective, lower, upper, "x");
+    if (rval) {
+        printf("not ok %i - Unable to create variable\n", test_id);
+        goto CLEANUP;
+    }
+
+    /* Test solving with no constraints */
+    int status = 0;
+    rval = QSexact_solver(p, NULL, NULL, NULL, DUAL_SIMPLEX, &status);
+    if (rval) {
+        printf("not ok %i - Failed solving problem\n", test_id);
+        goto CLEANUP;
+    }
+
+    if (status != QS_LP_OPTIMAL) {
+        printf("not ok %i - Did not find an optimal solution.\n", test_id);
+        goto CLEANUP;
+    }
+
+    printf("ok %i - Solution was found\n", test_id);
+
+CLEANUP:
+    mpq_clear(objective);
+    mpq_clear(lower);
+    mpq_clear(upper);
+    if (p) mpq_QSfree_prob(p);
+}
+
 static void test_solution_is_optimal(int test_id)
 {
     mpq_QSprob p = NULL;
@@ -597,6 +643,7 @@ int main(int ac, char **av)
         test_delete_column_in_empty_problem,
         test_row_count,
         test_col_count,
+        test_solve_no_constraints,
         test_solution_is_optimal,
         test_solution_objective,
         test_solution_get_variables,


### PR DESCRIPTION
Fixes bug where solving a problem with no constraints resulted in an infinite loop. The row symbol table was not properly initialized when no constraints were defined. To work around this, the symbol table is now forced to be initialized before the call that previously resulted in an infinite loop.

This still fails if no variables are defined but a change was made in the order of initializations in ILLsimplex() so that a proper failure happens instead of a segfault.