### PR TITLE
allocrus: Avoid having to name type when freeing

### DIFF
--- a/qsopt_ex/allocrus.c
+++ b/qsopt_ex/allocrus.c
@@ -140,12 +140,6 @@ void *ILLutil_allocrus (
 void ILLutil_freerus (
 	void *p)
 {
-	if (!p)
-	{
-		//QSlog("Warning: null pointer freed");
-		return;
-	}
-
 	free (p);
 }
 
@@ -247,7 +241,7 @@ void ILLutil_bigchunkfree (
 	/* This copy is necessary since ILL_FREE zeros its first argument */
 	ILLbigchunk *p = bp->this_chunk;
 
-	ILL_IFFREE (p, ILLbigchunk);
+	ILL_IFFREE(p);
 }
 
 void ILLptrworld_init (

--- a/qsopt_ex/allocrus.h
+++ b/qsopt_ex/allocrus.h
@@ -52,11 +52,10 @@ extern int ILLTRACE_MALLOC;
     (((ILLTRACE_MALLOC) ? QSlog("%s.%d: %s: ILL_UTIL_SAFE_MALLOC: %s = %d * %s\n", __FILE__, __LINE__, __DEV_FUNCTION__, #varname, nnum, #type) : 0), \
      (type *) ILLutil_allocrus (((size_t) (nnum)) * sizeof (type)))
 
-#define ILL_IFFREE(object,type) {                                           \
-    if ((object)) {                                                        \
-       ILLutil_freerus ((void *) (object));                                 \
-       object = (type *) NULL;                                             \
-    }}
+#define ILL_IFFREE(object) {                                    \
+       ILLutil_freerus(object);                                 \
+       object = NULL;                                           \
+    }
 
 #define ILL_PTRWORLD_ALLOC_ROUTINE(type, ptr_alloc_r, ptr_bulkalloc_r)        \
                                                                              \

--- a/qsopt_ex/basis.c
+++ b/qsopt_ex/basis.c
@@ -109,10 +109,10 @@ void EGLPNUM_TYPENAME_ILLbasis_init_basisinfo (
 void EGLPNUM_TYPENAME_ILLbasis_free_basisinfo (
 	EGLPNUM_TYPENAME_lpinfo * lp)
 {
-	ILL_IFFREE (lp->baz, int);
-	ILL_IFFREE (lp->nbaz, int);
-	ILL_IFFREE (lp->vstat, int);
-	ILL_IFFREE (lp->vindex, int);
+	ILL_IFFREE(lp->baz);
+	ILL_IFFREE(lp->nbaz);
+	ILL_IFFREE(lp->vstat);
+	ILL_IFFREE(lp->vindex);
 
 	if (lp->f)
 	{
@@ -124,7 +124,7 @@ void EGLPNUM_TYPENAME_ILLbasis_free_basisinfo (
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->f->maxelem_factor);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->f->maxelem_cur);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->f->partial_cur);
-		ILL_IFFREE (lp->f, EGLPNUM_TYPENAME_factor_work);
+		ILL_IFFREE(lp->f);
 	}
 }
 
@@ -790,13 +790,13 @@ CLEANUP:
 	EGLPNUM_TYPENAME_EGlpNumClearVar (cmax);
 	if (rval)
 		EGLPNUM_TYPENAME_ILLbasis_free_basisinfo (lp);
-	ILL_IFFREE (irow, int);
-	ILL_IFFREE (rrow, int);
+	ILL_IFFREE(irow);
+	ILL_IFFREE(rrow);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (v);
-	ILL_IFFREE (perm, int);
-	ILL_IFFREE (porder, int);
-	ILL_IFFREE (unitcol, int);
+	ILL_IFFREE(perm);
+	ILL_IFFREE(porder);
+	ILL_IFFREE(unitcol);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (qpenalty);
 	EGLPNUM_TYPENAME_ILLbasis_clear_vardata (&vd);
@@ -1045,18 +1045,18 @@ CLEANUP:
 	if (rval)
 		EGLPNUM_TYPENAME_ILLbasis_free_basisinfo (lp);
 
-	ILL_IFFREE (irow, int);
-	ILL_IFFREE (rrow, int);
+	ILL_IFFREE(irow);
+	ILL_IFFREE(rrow);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (v);
-	ILL_IFFREE (unitcol, int);
-	ILL_IFFREE (icol, int);
-	ILL_IFFREE (rcol, int);
+	ILL_IFFREE(unitcol);
+	ILL_IFFREE(icol);
+	ILL_IFFREE(rcol);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (dj);
-	ILL_IFFREE (perm, int);
-	ILL_IFFREE (porder, int);
-	ILL_IFFREE (plen, int);
+	ILL_IFFREE(perm);
+	ILL_IFFREE(porder);
+	ILL_IFFREE(plen);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (qpenalty);
 	EGLPNUM_TYPENAME_EGlpNumClearVar (seldj);
@@ -1155,7 +1155,7 @@ int EGLPNUM_TYPENAME_ILLbasis_get_initial (
 	lp->basisid = 0;
 
 CLEANUP:
-	ILL_IFFREE (vstat, int);
+	ILL_IFFREE(vstat);
 
 	EG_RETURN (rval);
 }
@@ -1346,8 +1346,8 @@ CLEANUP:
 		if (fil != NULL)
 			EGioClose (fil);
 	}
-	ILL_IFFREE (vstat1, int);
-	ILL_IFFREE (vstat2, int);
+	ILL_IFFREE(vstat1);
+	ILL_IFFREE(vstat2);
 
 	EGLPNUM_TYPENAME_EGlpNumClearVar (pinf1);
 	EGLPNUM_TYPENAME_EGlpNumClearVar (pinf2);
@@ -1417,8 +1417,8 @@ int EGLPNUM_TYPENAME_ILLbasis_factor (
 				EGLPNUM_TYPENAME_ILLfct_update_basis_info (lp, eindex, lindex, lvstat);
 				lp->basisid++;
 			}
-			ILL_IFFREE (singr, int);
-			ILL_IFFREE (singc, int);
+			ILL_IFFREE(singr);
+			ILL_IFFREE(singc);
 		}
 
 	} while (nsing != 0);
@@ -1426,8 +1426,8 @@ int EGLPNUM_TYPENAME_ILLbasis_factor (
 	lp->fbasisid = lp->basisid;
 
 CLEANUP:
-	ILL_IFFREE (singr, int);
-	ILL_IFFREE (singc, int);
+	ILL_IFFREE(singr);
+	ILL_IFFREE(singc);
 
 	if (rval)
 		QSlog("Error: unknown in %s", __func__);

--- a/qsopt_ex/binary.c
+++ b/qsopt_ex/binary.c
@@ -271,7 +271,7 @@ CLEANUP:
 	if (minf.que)
 	{
 		EGLPNUM_TYPENAME_ILLutil_priority_free (minf.que);
-		ILL_IFFREE (minf.que, EGLPNUM_TYPENAME_ILLpriority);
+		ILL_IFFREE(minf.que);
 	}
 	cleanup_mip (&minf);
 	free_mipinfo (&minf);
@@ -344,7 +344,7 @@ static int startup_mip (
 	if (qlp->sinfo)
 	{															/* Free the presolve LP and work with orginal */
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (qlp->sinfo);
-		ILL_IFFREE (qlp->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+		ILL_IFFREE(qlp->sinfo);
 	}
 
 
@@ -939,8 +939,8 @@ static int fix_variables (
 
 CLEANUP:
 
-	ILL_IFFREE (new_indx, int);
-	ILL_IFFREE (new_lu, char);
+	ILL_IFFREE(new_indx);
+	ILL_IFFREE(new_lu);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (dj);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (new_bounds);
@@ -1226,8 +1226,8 @@ CLEANUP:
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (newup);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (fval);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (xlist);
-	ILL_IFFREE (candidatelist, int);
-	ILL_IFFREE (needlist, int);
+	ILL_IFFREE(candidatelist);
+	ILL_IFFREE(needlist);
 
 	return rval;
 }
@@ -1304,7 +1304,7 @@ static int find_strong_branch (
 			{
 				newlist[i] = candidatelist[perm[i]];
 			}
-			ILL_IFFREE (candidatelist, int);
+			ILL_IFFREE(candidatelist);
 
 			candidatelist = newlist;
 			newlist = 0;
@@ -1360,9 +1360,9 @@ CLEANUP:
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (xlist);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (uppen);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (downpen);
-	ILL_IFFREE (candidatelist, int);
-	ILL_IFFREE (newlist, int);
-	ILL_IFFREE (perm, int);
+	ILL_IFFREE(candidatelist);
+	ILL_IFFREE(newlist);
+	ILL_IFFREE(perm);
 
 	ILL_RETURN (rval, "find_strong_branch");
 }
@@ -1745,10 +1745,10 @@ static void free_bbnode (
 	{
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (b->rownorms);
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (b->bounds);
-		ILL_IFFREE (b->cstat, char);
-		ILL_IFFREE (b->rstat, char);
-		ILL_IFFREE (b->bound_indx, int);
-		ILL_IFFREE (b->lu, char);
+		ILL_IFFREE(b->cstat);
+		ILL_IFFREE(b->rstat);
+		ILL_IFFREE(b->bound_indx);
+		ILL_IFFREE(b->lu);
 
 		EGLPNUM_TYPENAME_EGlpNumClearVar ((b->bound));
 		memset (b, 0, sizeof (bbnode));

--- a/qsopt_ex/dheaps_i.c
+++ b/qsopt_ex/dheaps_i.c
@@ -161,8 +161,8 @@ CLEANUP:
 void EGLPNUM_TYPENAME_ILLutil_dheap_free (
 	EGLPNUM_TYPENAME_ILLdheap * h)
 {
-	ILL_IFFREE (h->entry, int);
-	ILL_IFFREE (h->loc, int);
+	ILL_IFFREE(h->entry);
+	ILL_IFFREE(h->loc);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (h->key);
 }

--- a/qsopt_ex/dstruct.c
+++ b/qsopt_ex/dstruct.c
@@ -60,7 +60,7 @@ void EGLPNUM_TYPENAME_ILLsvector_init (
 void EGLPNUM_TYPENAME_ILLsvector_free (
 	EGLPNUM_TYPENAME_svector * s)
 {
-	ILL_IFFREE (s->indx, int);
+	ILL_IFFREE(s->indx);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (s->coef);
 	s->nzcnt = 0;
@@ -86,7 +86,7 @@ int EGLPNUM_TYPENAME_ILLsvector_alloc (
 	}
 	return 0;
 CLEANUP:
-	ILL_IFFREE (s->indx, int);
+	ILL_IFFREE(s->indx);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (s->coef);
 	ILL_RETURN (rval, "EGLPNUM_TYPENAME_ILLsvector_alloc");
 }
@@ -420,8 +420,8 @@ void EGLPNUM_TYPENAME_ILLheap_free (
 {
 	if (h->hexist)
 	{
-		ILL_IFFREE (h->entry, int);
-		ILL_IFFREE (h->loc, int);
+		ILL_IFFREE(h->entry);
+		ILL_IFFREE(h->loc);
 
 		h->hexist = 0;
 		h->maxsize = 0;
@@ -464,9 +464,9 @@ void EGLPNUM_TYPENAME_ILLmatrix_free (
 	if (A)
 	{
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (A->matval);
-		ILL_IFFREE (A->matcnt, int);
-		ILL_IFFREE (A->matbeg, int);
-		ILL_IFFREE (A->matind, int);
+		ILL_IFFREE(A->matcnt);
+		ILL_IFFREE(A->matbeg);
+		ILL_IFFREE(A->matind);
 
 		EGLPNUM_TYPENAME_ILLmatrix_init (A);
 	}

--- a/qsopt_ex/editor.c
+++ b/qsopt_ex/editor.c
@@ -469,7 +469,7 @@ static char *get_row_col_name (
 CLEANUP:
 	if (rval != 0)
 	{
-		ILL_IFFREE (thename, char);
+		ILL_IFFREE(thename);
 	}
 	return thename;
 }
@@ -591,7 +591,7 @@ CLEANUP:
 	{
 		if (rval != 0)
 			ILLsymboltab_delete (&lp->rowtab, name);
-		ILL_IFFREE (name, char);
+		ILL_IFFREE(name);
 	}
 	if (rval != 0)
 	{
@@ -662,7 +662,7 @@ CLEANUP:
 	{
 		if (rval != 0)
 			ILLsymboltab_delete (&lp->rowtab, name[0]);
-		ILL_IFFREE (name[0], char);
+		ILL_IFFREE(name[0]);
 	}
 	if (rval != 0)
 	{
@@ -671,7 +671,7 @@ CLEANUP:
 	EGLPNUM_TYPENAME_ILLraw_clear_matrix (lp);
 	if (transposed)
 		transpose (lp);
-	ILL_IFFREE (name[0], char);
+	ILL_IFFREE(name[0]);
 
 	EGLPNUM_TYPENAME_EGlpNumClearVar (*obj);
 	EGLPNUM_TYPENAME_EGlpNumClearVar (*lower);
@@ -725,7 +725,7 @@ static void new_row (
 		ILLsymboltab_register (&lp->rowtab, rname, &ind, &hit);
 	}
 CLEANUP:
-	ILL_IFFREE (rowname, char);
+	ILL_IFFREE(rowname);
 }
 #endif
 #endif

--- a/qsopt_ex/exact.c
+++ b/qsopt_ex/exact.c
@@ -1017,18 +1017,18 @@ static int QSexact_basis_status (mpq_QSdata * p_mpq,
 	{
 		mpq_ILLlp_cache_free (p_mpq->cache);
 		mpq_clear (p_mpq->cache->val);
-		ILL_IFFREE (p_mpq->cache, mpq_ILLlp_cache); 
+		ILL_IFFREE(p_mpq->cache);
 	}
 	p_mpq->qstatus = QS_LP_MODIFIED;
 	if(p_mpq->qslp->sinfo) 
 	{
 		mpq_ILLlp_sinfo_free(p_mpq->qslp->sinfo);
-		ILL_IFFREE(p_mpq->qslp->sinfo, mpq_ILLlp_sinfo); 
+		ILL_IFFREE(p_mpq->qslp->sinfo);
 	}
 	if(p_mpq->qslp->rA)
 	{
 		mpq_ILLlp_rows_clear (p_mpq->qslp->rA);
-		ILL_IFFREE (p_mpq->qslp->rA, mpq_ILLlp_rows);
+		ILL_IFFREE(p_mpq->qslp->rA);
 	}
 	mpq_free_internal_lpinfo (p_mpq->lp);
 	mpq_init_internal_lpinfo (p_mpq->lp);
@@ -1119,19 +1119,19 @@ int QSexact_basis_optimalstatus(
    {
       mpq_ILLlp_cache_free (p_mpq->cache);
       mpq_clear (p_mpq->cache->val);
-      ILL_IFFREE (p_mpq->cache, mpq_ILLlp_cache); 
+      ILL_IFFREE(p_mpq->cache);
    }
    p_mpq->qstatus = QS_LP_MODIFIED;
 
    if(p_mpq->qslp->sinfo) 
    {
       mpq_ILLlp_sinfo_free(p_mpq->qslp->sinfo);
-      ILL_IFFREE(p_mpq->qslp->sinfo, mpq_ILLlp_sinfo); 
+      ILL_IFFREE(p_mpq->qslp->sinfo);
    }
    if(p_mpq->qslp->rA)
    {
       mpq_ILLlp_rows_clear (p_mpq->qslp->rA);
-      ILL_IFFREE (p_mpq->qslp->rA, mpq_ILLlp_rows);
+      ILL_IFFREE(p_mpq->qslp->rA);
    }
 
    mpq_free_internal_lpinfo (p_mpq->lp);
@@ -1203,20 +1203,20 @@ int QSexact_basis_dualstatus(
 	{
 		mpq_ILLlp_cache_free (p_mpq->cache);
 		mpq_clear (p_mpq->cache->val);
-		ILL_IFFREE (p_mpq->cache, mpq_ILLlp_cache); 
+		ILL_IFFREE(p_mpq->cache);
 	}
 	p_mpq->qstatus = QS_LP_MODIFIED;
 
 	if(p_mpq->qslp->sinfo) 
 	{
 		mpq_ILLlp_sinfo_free(p_mpq->qslp->sinfo);
-		ILL_IFFREE(p_mpq->qslp->sinfo, mpq_ILLlp_sinfo); 
+		ILL_IFFREE(p_mpq->qslp->sinfo);
 	}
 
 	if(p_mpq->qslp->rA)
 	{
 		mpq_ILLlp_rows_clear (p_mpq->qslp->rA);
-		ILL_IFFREE (p_mpq->qslp->rA, mpq_ILLlp_rows);
+		ILL_IFFREE(p_mpq->qslp->rA);
 	}
 
 	mpq_free_internal_lpinfo (p_mpq->lp);
@@ -1774,8 +1774,8 @@ CLEANUP:
 	mpf_EGlpNumFreeArray (y_mpf);
 	if (ebasis && basis)
 	{
-		ILL_IFFREE (ebasis->cstat, char);
-		ILL_IFFREE (ebasis->rstat, char);
+		ILL_IFFREE(ebasis->cstat);
+		ILL_IFFREE(ebasis->rstat);
 		ebasis->nstruct = basis->nstruct;
 		ebasis->nrows = basis->nrows;
 		ebasis->cstat = basis->cstat;

--- a/qsopt_ex/factor.c
+++ b/qsopt_ex/factor.c
@@ -150,9 +150,9 @@ void EGLPNUM_TYPENAME_ILLfactor_free_factor_work (
 	}
 #endif
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f->work_coef);
-	ILL_IFFREE (f->work_indx, int);
+	ILL_IFFREE(f->work_indx);
 
-	ILL_IFFREE (f->uc_inf, EGLPNUM_TYPENAME_uc_info);
+	ILL_IFFREE(f->uc_inf);
 	if (f->dim + f->max_k > 0 && f->ur_inf)
 	{
 		unsigned int i = f->dim + f->max_k + 1;
@@ -160,31 +160,31 @@ void EGLPNUM_TYPENAME_ILLfactor_free_factor_work (
 		while (i--)
 			EGLPNUM_TYPENAME_EGlpNumClearVar (f->ur_inf[i].max);
 	}
-	ILL_IFFREE (f->ur_inf, EGLPNUM_TYPENAME_ur_info);
-	ILL_IFFREE (f->lc_inf, EGLPNUM_TYPENAME_lc_info);
-	ILL_IFFREE (f->lr_inf, EGLPNUM_TYPENAME_lr_info);
-	ILL_IFFREE (f->er_inf, EGLPNUM_TYPENAME_er_info);
-	ILL_IFFREE (f->ucindx, int);
-	ILL_IFFREE (f->ucrind, int);
+	ILL_IFFREE(f->ur_inf);
+	ILL_IFFREE(f->lc_inf);
+	ILL_IFFREE(f->lr_inf);
+	ILL_IFFREE(f->er_inf);
+	ILL_IFFREE(f->ucindx);
+	ILL_IFFREE(f->ucrind);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f->uccoef);
-	ILL_IFFREE (f->urindx, int);
-	ILL_IFFREE (f->urcind, int);
+	ILL_IFFREE(f->urindx);
+	ILL_IFFREE(f->urcind);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f->urcoef);
-	ILL_IFFREE (f->lcindx, int);
+	ILL_IFFREE(f->lcindx);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f->lccoef);
-	ILL_IFFREE (f->lrindx, int);
+	ILL_IFFREE(f->lrindx);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f->lrcoef);
-	ILL_IFFREE (f->erindx, int);
+	ILL_IFFREE(f->erindx);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f->ercoef);
-	ILL_IFFREE (f->rperm, int);
-	ILL_IFFREE (f->rrank, int);
-	ILL_IFFREE (f->cperm, int);
-	ILL_IFFREE (f->crank, int);
+	ILL_IFFREE(f->rperm);
+	ILL_IFFREE(f->rrank);
+	ILL_IFFREE(f->cperm);
+	ILL_IFFREE(f->crank);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f->dmat);
 	EGLPNUM_TYPENAME_ILLsvector_free (&f->xtmp);
@@ -835,12 +835,12 @@ static int make_ur_space (
 	f->urcoef = new_urcoef;
 	new_urcoef = 0;
 
-	ILL_IFFREE (f->urindx, int);
+	ILL_IFFREE(f->urindx);
 
 	f->urindx = new_urindx;
 	new_urindx = 0;
 
-	ILL_IFFREE (f->urcind, int);
+	ILL_IFFREE(f->urcind);
 
 	f->urcind = new_urcind;
 	new_urcind = 0;
@@ -856,9 +856,9 @@ static int make_ur_space (
 	rval = 0;
 
 CLEANUP:
-	ILL_IFFREE (new_urcoef, EGLPNUM_TYPE);
-	ILL_IFFREE (new_urindx, int);
-	ILL_IFFREE (new_urcind, int);
+	ILL_IFFREE(new_urcoef);
+	ILL_IFFREE(new_urindx);
+	ILL_IFFREE(new_urcind);
 
 	EG_RETURN (rval);
 }
@@ -945,12 +945,12 @@ static int make_uc_space (
 	f->uccoef = new_uccoef;
 	new_uccoef = 0;
 
-	ILL_IFFREE (f->ucindx, int);
+	ILL_IFFREE(f->ucindx);
 
 	f->ucindx = new_ucindx;
 	new_ucindx = 0;
 
-	ILL_IFFREE (f->ucrind, int);
+	ILL_IFFREE(f->ucrind);
 
 	f->ucrind = new_ucrind;
 	new_ucrind = 0;
@@ -966,9 +966,9 @@ static int make_uc_space (
 	rval = 0;
 
 CLEANUP:
-	ILL_IFFREE (new_uccoef, EGLPNUM_TYPE);
-	ILL_IFFREE (new_ucindx, int);
-	ILL_IFFREE (new_ucrind, int);
+	ILL_IFFREE(new_uccoef);
+	ILL_IFFREE(new_ucindx);
+	ILL_IFFREE(new_ucrind);
 
 	EG_RETURN (rval);
 }
@@ -1008,7 +1008,7 @@ static int make_lc_space (
 	f->lccoef = new_lccoef;
 	new_lccoef = 0;
 
-	ILL_IFFREE (lcindx, int);
+	ILL_IFFREE(lcindx);
 
 	f->lcindx = new_lcindx;
 	new_lcindx = 0;
@@ -1022,8 +1022,8 @@ static int make_lc_space (
 	rval = 0;
 
 CLEANUP:
-	ILL_IFFREE (new_lccoef, EGLPNUM_TYPE);
-	ILL_IFFREE (new_lcindx, int);
+	ILL_IFFREE(new_lccoef);
+	ILL_IFFREE(new_lcindx);
 
 	EG_RETURN (rval);
 }
@@ -1824,7 +1824,7 @@ static int create_factor_space (
 
 	if (f->urindx == 0 || f->urcoef == 0)
 	{
-		ILL_IFFREE (f->urindx, int);
+		ILL_IFFREE(f->urindx);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (f->urcoef);
 		f->ur_space = nzcnt * f->ur_space_mul;
@@ -1835,7 +1835,7 @@ static int create_factor_space (
 
 	if (f->lcindx == 0 || f->lccoef == 0)
 	{
-		ILL_IFFREE (f->lcindx, int);
+		ILL_IFFREE(f->lcindx);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (f->lccoef);
 		f->lc_space = nzcnt * f->lc_space_mul;
@@ -2060,19 +2060,19 @@ static int build_iteration_u_data (
 	uccoef = EGLPNUM_TYPENAME_EGlpNumAllocArray (nzcnt);
 	f->uccoef = uccoef;
 
-	ILL_IFFREE (f->ucrind, int);
+	ILL_IFFREE(f->ucrind);
 	ILL_SAFE_MALLOC (ucrind, nzcnt, int);
 
 	f->ucrind = ucrind;
 
-	ILL_IFFREE (f->urcind, int);
+	ILL_IFFREE(f->urcind);
 	ILL_SAFE_MALLOC (urcind, f->ur_space, int);
 
 	f->urcind = urcind;
 
 	if (uc_space < nzcnt)
 	{
-		ILL_IFFREE (f->ucindx, int);
+		ILL_IFFREE(f->ucindx);
 		ILL_SAFE_MALLOC (f->ucindx, nzcnt + 1, int);
 	}
 	f->uc_space = nzcnt;
@@ -2209,7 +2209,7 @@ static int build_iteration_l_data (
 		f->lrcoef = lrcoef;
 	}
 
-	ILL_IFFREE (f->lrindx, int);
+	ILL_IFFREE(f->lrindx);
 	ILL_SAFE_MALLOC (lrindx, nzcnt + 1, int);
 
 	f->lrindx = lrindx;
@@ -2306,8 +2306,8 @@ static int handle_singularity (
 	singc = 0;
 
 CLEANUP:
-	ILL_IFFREE (singr, int);
-	ILL_IFFREE (singc, int);
+	ILL_IFFREE(singr);
+	ILL_IFFREE(singc);
 
 	EG_RETURN (rval);
 }
@@ -5302,7 +5302,7 @@ static int sparse_eliminate_row (
 
 CLEANUP:
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (newr.coef);
-	ILL_IFFREE (newr.indx, int);
+	ILL_IFFREE(newr.indx);
 
 	/* Bico 031210 - chg from ILL_RETURN */
 	EG_RETURN (rval);

--- a/qsopt_ex/fct.c
+++ b/qsopt_ex/fct.c
@@ -69,7 +69,7 @@ void EGLPNUM_TYPENAME_ILLfct_free_bndinfo (
 {
 	EGLPNUM_TYPENAME_EGlpNumClearVar ((binfo->pbound));
 	EGLPNUM_TYPENAME_EGlpNumClearVar ((binfo->cbound));
-	ILL_IFFREE (binfo, EGLPNUM_TYPENAME_bndinfo);
+	ILL_IFFREE(binfo);
 	return;
 }
 
@@ -1024,7 +1024,7 @@ void EGLPNUM_TYPENAME_ILLfct_unroll_bound_change (
 		nptr = bptr->next;
 		EGLPNUM_TYPENAME_EGlpNumClearVar ((bptr->cbound));
 		EGLPNUM_TYPENAME_EGlpNumClearVar ((bptr->pbound));
-		ILL_IFFREE (bptr, EGLPNUM_TYPENAME_bndinfo);
+		ILL_IFFREE(bptr);
 		bptr = nptr;
 		lp->nbchange--;
 	}
@@ -1172,7 +1172,7 @@ CLEANUP:
 	{
 		EGLPNUM_TYPENAME_EGlpNumClearVar ((ncoef->pcoef));
 		EGLPNUM_TYPENAME_EGlpNumClearVar ((ncoef->ccoef));
-		ILL_IFFREE (ncoef, EGLPNUM_TYPENAME_coefinfo);
+		ILL_IFFREE(ncoef);
 	}
 	EG_RETURN (rval);
 }
@@ -1198,7 +1198,7 @@ void EGLPNUM_TYPENAME_ILLfct_unroll_coef_change (
 		nptr = cptr->next;
 		EGLPNUM_TYPENAME_EGlpNumClearVar ((cptr->pcoef));
 		EGLPNUM_TYPENAME_EGlpNumClearVar ((cptr->ccoef));
-		ILL_IFFREE (cptr, EGLPNUM_TYPENAME_coefinfo);
+		ILL_IFFREE(cptr);
 		cptr = nptr;
 		lp->ncchange--;
 	}

--- a/qsopt_ex/format.c
+++ b/qsopt_ex/format.c
@@ -86,8 +86,8 @@ CLEANUP:
 void EGLPNUM_TYPENAME_ILLformat_error_delete (
 	EGLPNUM_TYPENAME_qsformat_error * error)
 {
-	ILL_IFFREE (error->desc, char);
-	ILL_IFFREE (error->theLine, char);
+	ILL_IFFREE(error->desc);
+	ILL_IFFREE(error->theLine);
 }
 
 void EGLPNUM_TYPENAME_ILLformat_error_print (
@@ -147,7 +147,7 @@ EGLPNUM_TYPENAME_qserror_collector *EGLPNUM_TYPENAME_ILLerror_collector_new (
 CLEANUP:
 	if (rval)
 	{
-		ILL_IFFREE (c, EGLPNUM_TYPENAME_qserror_collector);
+		ILL_IFFREE(c);
 	}
 	return c;
 }
@@ -161,7 +161,7 @@ EGLPNUM_TYPENAME_qserror_collector *EGLPNUM_TYPENAME_ILLerror_memory_collector_n
 void EGLPNUM_TYPENAME_ILLerror_collector_free (
 	EGLPNUM_TYPENAME_qserror_collector * c)
 {
-	ILL_IFFREE (c, EGLPNUM_TYPENAME_qserror_collector);
+	ILL_IFFREE(c);
 }
 
 EGLPNUM_TYPENAME_qserror_memory *EGLPNUM_TYPENAME_ILLerror_memory_create (
@@ -193,10 +193,10 @@ void EGLPNUM_TYPENAME_ILLerror_memory_free (
 		while (ths != NULL)
 		{
 			nxt = ths->next;
-			ILL_IFFREE (ths, EGLPNUM_TYPENAME_qsformat_error);
+			ILL_IFFREE(ths);
 			ths = nxt;
 		}
-		ILL_IFFREE (mem, EGLPNUM_TYPENAME_qserror_memory);
+		ILL_IFFREE(mem);
 	}
 }
 
@@ -225,7 +225,7 @@ CLEANUP:
 	if (rval)
 	{
 		EGLPNUM_TYPENAME_ILLformat_error_delete (e);
-		ILL_IFFREE (e, EGLPNUM_TYPENAME_qsformat_error);
+		ILL_IFFREE(e);
 	}
 	return rval;
 }

--- a/qsopt_ex/lib.c
+++ b/qsopt_ex/lib.c
@@ -533,7 +533,7 @@ int EGLPNUM_TYPENAME_ILLlib_basis_order (
 
 CLEANUP:
 
-	ILL_IFFREE (invmap, int);
+	ILL_IFFREE(invmap);
 
 	EG_RETURN (rval);
 }
@@ -564,7 +564,7 @@ int EGLPNUM_TYPENAME_ILLlib_chgbnd (
 	if (lp->O->sinfo)
 	{															/* Presolve LP is no longer valid, free the data */
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (lp->O->sinfo);
-		ILL_IFFREE (lp->O->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+		ILL_IFFREE(lp->O->sinfo);
 	}
 
 	col = lp->O->structmap[indx];
@@ -941,8 +941,8 @@ int EGLPNUM_TYPENAME_ILLlib_newrows (
 
 CLEANUP:
 
-	ILL_IFFREE (rmatcnt, int);
-	ILL_IFFREE (rmatbeg, int);
+	ILL_IFFREE(rmatcnt);
+	ILL_IFFREE(rmatbeg);
 
 	EG_RETURN (rval);
 }
@@ -1061,12 +1061,12 @@ int EGLPNUM_TYPENAME_ILLlib_addrows (
 																			bcnt, bbeg, bindi, bval);
 		CHECKRVALG (rval, CLEANUP);
 
-		ILL_IFFREE (bcnt, int);
-		ILL_IFFREE (bbeg, int);
-		ILL_IFFREE (bindi, int);
+		ILL_IFFREE(bcnt);
+		ILL_IFFREE(bbeg);
+		ILL_IFFREE(bindi);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (bval);
-		ILL_IFFREE (imap, int);
+		ILL_IFFREE(imap);
 
 		badfactor = 1;
 	}
@@ -1138,14 +1138,14 @@ int EGLPNUM_TYPENAME_ILLlib_addrows (
 
 CLEANUP:
 
-	ILL_IFFREE (bcnt, int);
-	ILL_IFFREE (bbeg, int);
-	ILL_IFFREE (bindi, int);
+	ILL_IFFREE(bcnt);
+	ILL_IFFREE(bbeg);
+	ILL_IFFREE(bindi);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (bval);
-	ILL_IFFREE (imap, int);
-	ILL_IFFREE (jstat, int);
-	ILL_IFFREE (rindi, int);
+	ILL_IFFREE(imap);
+	ILL_IFFREE(jstat);
+	ILL_IFFREE(rindi);
 
 	EGLPNUM_TYPENAME_EGlpNumClearVar (rng);
 	EG_RETURN (rval);
@@ -1187,13 +1187,13 @@ int EGLPNUM_TYPENAME_ILLlib_addrow (
 	if (qslp->rA)
 	{															/* After an addrow call, needs to be updated */
 		EGLPNUM_TYPENAME_ILLlp_rows_clear (qslp->rA);
-		ILL_IFFREE (qslp->rA, EGLPNUM_TYPENAME_ILLlp_rows);
+		ILL_IFFREE(qslp->rA);
 	}
 
 	if (qslp->sinfo)
 	{															/* Presolve LP is no longer valid, free the data */
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (qslp->sinfo);
-		ILL_IFFREE (qslp->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+		ILL_IFFREE(qslp->sinfo);
 	}
 
 	nrows = qslp->nrows;
@@ -1329,7 +1329,7 @@ int EGLPNUM_TYPENAME_ILLlib_addrow (
 	}
 
 CLEANUP:
-	ILL_IFFREE (tempind, int);
+	ILL_IFFREE(tempind);
 
 	EGLPNUM_TYPENAME_EGlpNumClearVar (tval[0]);
 	EG_RETURN (rval);
@@ -1390,7 +1390,7 @@ int EGLPNUM_TYPENAME_ILLlib_delrows (
 	if (qslp->rA)
 	{															/* After a delrow call, needs to be updated */
 		EGLPNUM_TYPENAME_ILLlp_rows_clear (qslp->rA);
-		ILL_IFFREE (qslp->rA, EGLPNUM_TYPENAME_ILLlp_rows);
+		ILL_IFFREE(qslp->rA);
 	}
 
 	nrows = A->matrows;
@@ -1520,7 +1520,7 @@ int EGLPNUM_TYPENAME_ILLlib_delrows (
 			{
 				rval = ILLsymboltab_delete (&qslp->rowtab, qslp->rownames[i]);
 				CHECKRVALG (rval, CLEANUP);
-				ILL_IFFREE (qslp->rownames[i], char);
+				ILL_IFFREE(qslp->rownames[i]);
 			}
 		}
 	}
@@ -1602,10 +1602,10 @@ int EGLPNUM_TYPENAME_ILLlib_delrows (
 	}
 CLEANUP:
 
-	ILL_IFFREE (rowmark, char);
-	ILL_IFFREE (colmark, char);
-	ILL_IFFREE (newcolindex, int);
-	ILL_IFFREE (newrowindex, int);
+	ILL_IFFREE(rowmark);
+	ILL_IFFREE(colmark);
+	ILL_IFFREE(newcolindex);
+	ILL_IFFREE(newrowindex);
 
 	EG_RETURN (rval);
 }
@@ -1652,7 +1652,7 @@ int EGLPNUM_TYPENAME_ILLlib_delcols (
 	if (qslp->rA)
 	{															/* After a delcol call, needs to be updated */
 		EGLPNUM_TYPENAME_ILLlp_rows_clear (qslp->rA);
-		ILL_IFFREE (qslp->rA, EGLPNUM_TYPENAME_ILLlp_rows);
+		ILL_IFFREE(qslp->rA);
 	}
 
 	ILL_SAFE_MALLOC (colmark, ncols, char);
@@ -1715,7 +1715,7 @@ int EGLPNUM_TYPENAME_ILLlib_delcols (
 
 CLEANUP:
 
-	ILL_IFFREE (colmark, char);
+	ILL_IFFREE(colmark);
 
 	EG_RETURN (rval);
 }
@@ -1824,7 +1824,7 @@ static int delcols_work (
 		{
 			rval = ILLsymboltab_delete (&qslp->coltab, qslp->colnames[i]);
 			CHECKRVALG (rval, CLEANUP);
-			ILL_IFFREE (qslp->colnames[i], char);
+			ILL_IFFREE(qslp->colnames[i]);
 		}
 	}
 
@@ -1837,7 +1837,7 @@ static int delcols_work (
 
 CLEANUP:
 
-	ILL_IFFREE (newcolindex, int);
+	ILL_IFFREE(newcolindex);
 
 	EG_RETURN (rval);
 }
@@ -1914,13 +1914,13 @@ int EGLPNUM_TYPENAME_ILLlib_chgcoef (
 	if (qslp->rA)
 	{															/* After a chgcoef call, needs to be updated */
 		EGLPNUM_TYPENAME_ILLlp_rows_clear (qslp->rA);
-		ILL_IFFREE (qslp->rA, EGLPNUM_TYPENAME_ILLlp_rows);
+		ILL_IFFREE(qslp->rA);
 	}
 
 	if (qslp->sinfo)
 	{															/* Presolve LP is no longer valid, free the data */
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (qslp->sinfo);
-		ILL_IFFREE (qslp->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+		ILL_IFFREE(qslp->sinfo);
 	}
 
 	j = qslp->structmap[colindex];
@@ -2073,8 +2073,8 @@ int EGLPNUM_TYPENAME_ILLlib_newcols (
 
 CLEANUP:
 
-	ILL_IFFREE (cmatcnt, int);
-	ILL_IFFREE (cmatbeg, int);
+	ILL_IFFREE(cmatcnt);
+	ILL_IFFREE(cmatbeg);
 
 	EG_RETURN (rval);
 }
@@ -2155,13 +2155,13 @@ int EGLPNUM_TYPENAME_ILLlib_addcol (
 	if (qslp->rA)
 	{															/* After an addcol call, needs to be updated */
 		EGLPNUM_TYPENAME_ILLlp_rows_clear (qslp->rA);
-		ILL_IFFREE (qslp->rA, EGLPNUM_TYPENAME_ILLlp_rows);
+		ILL_IFFREE(qslp->rA);
 	}
 
 	if (qslp->sinfo)
 	{															/* Presolve LP is no longer valid, free the data */
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (qslp->sinfo);
-		ILL_IFFREE (qslp->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+		ILL_IFFREE(qslp->sinfo);
 	}
 
 
@@ -2518,8 +2518,8 @@ static int matrix_addrow_end (
 		(A->matcnt[j])++;
 	}
 
-	ILL_IFFREE (A->matbeg, int);
-	ILL_IFFREE (A->matind, int);
+	ILL_IFFREE(A->matbeg);
+	ILL_IFFREE(A->matind);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (A->matval);
 
@@ -2531,8 +2531,8 @@ CLEANUP:
 
 	if (rval)
 	{
-		ILL_IFFREE (newbeg, int);
-		ILL_IFFREE (newind, int);
+		ILL_IFFREE(newbeg);
+		ILL_IFFREE(newind);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (newval);
 	}
@@ -2892,37 +2892,37 @@ int EGLPNUM_TYPENAME_ILLlib_getrows (
 
 CLEANUP:
 
-	ILL_IFFREE (allbeg, int);
-	ILL_IFFREE (allcnt, int);
-	ILL_IFFREE (allind, int);
+	ILL_IFFREE(allbeg);
+	ILL_IFFREE(allcnt);
+	ILL_IFFREE(allind);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (allval);
 
 	if (rval)
 	{
 		if (rowcnt)
-			ILL_IFFREE (*rowcnt, int);
+			ILL_IFFREE(*rowcnt);
 
 		if (rowbeg)
-			ILL_IFFREE (*rowbeg, int);
+			ILL_IFFREE(*rowbeg);
 
 		if (rowind)
-			ILL_IFFREE (*rowind, int);
+			ILL_IFFREE(*rowind);
 
 		if (rowval)
 			EGLPNUM_TYPENAME_EGlpNumFreeArray (*rowval);
 		if (rhs)
 			EGLPNUM_TYPENAME_EGlpNumFreeArray (*rhs);
 		if (sense)
-			ILL_IFFREE (*sense, char);
+			ILL_IFFREE(*sense);
 
 		if (names && (*names))
 		{
 			for (i = 0; i < num; i++)
 			{
-				ILL_IFFREE ((*names)[i], char);
+				ILL_IFFREE((*names)[i]);
 			}
-			ILL_IFFREE (*names, char *);
+			ILL_IFFREE(*names);
 		}
 	}
 
@@ -3100,13 +3100,13 @@ CLEANUP:
 	if (rval)
 	{
 		if (colcnt)
-			ILL_IFFREE (*colcnt, int);
+			ILL_IFFREE(*colcnt);
 
 		if (colbeg)
-			ILL_IFFREE (*colbeg, int);
+			ILL_IFFREE(*colbeg);
 
 		if (colind)
-			ILL_IFFREE (*colind, int);
+			ILL_IFFREE(*colind);
 
 		if (colval)
 			EGLPNUM_TYPENAME_EGlpNumFreeArray (*colval);
@@ -3120,12 +3120,12 @@ CLEANUP:
 		{
 			for (i = 0; i < num; i++)
 			{
-				ILL_IFFREE ((*names)[i], char);
+				ILL_IFFREE((*names)[i]);
 			}
-			ILL_IFFREE (*names, char *);
+			ILL_IFFREE(*names);
 		}
 	}
-	ILL_IFFREE (tlist, int);
+	ILL_IFFREE(tlist);
 
 	EG_RETURN (rval);
 }
@@ -3224,7 +3224,7 @@ int EGLPNUM_TYPENAME_ILLlib_chgobj (
 	if (lp->O->sinfo)
 	{															/* Presolve LP is no longer valid, free the data */
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (lp->O->sinfo);
-		ILL_IFFREE (lp->O->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+		ILL_IFFREE(lp->O->sinfo);
 	}
 
 	col = lp->O->structmap[indx];
@@ -3289,7 +3289,7 @@ int EGLPNUM_TYPENAME_ILLlib_chgrange (
 	if (lp->O->sinfo)
 	{/* Presolve LP is no longer valid, free the data */
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (lp->O->sinfo);
-		ILL_IFFREE (lp->O->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+		ILL_IFFREE(lp->O->sinfo);
 	}
 	
 	qslp = lp->O;
@@ -3341,7 +3341,7 @@ int EGLPNUM_TYPENAME_ILLlib_chgrhs (
 	if (lp->O->sinfo)
 	{															/* Presolve LP is no longer valid, free the data */
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (lp->O->sinfo);
-		ILL_IFFREE (lp->O->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+		ILL_IFFREE(lp->O->sinfo);
 	}
 
 	EGLPNUM_TYPENAME_EGlpNumCopy (lp->O->rhs[indx], coef);
@@ -3397,7 +3397,7 @@ CLEANUP:
 	{
 		for (i = 0; i < rcount; i++)
 		{
-			ILL_IFFREE (rownames[i], char);
+			ILL_IFFREE(rownames[i]);
 		}
 	}
 	EG_RETURN (rval);
@@ -3494,7 +3494,7 @@ CLEANUP:
 	{
 		for (i = 0; i < ccount; i++)
 		{
-			ILL_IFFREE (colnames[i], char);
+			ILL_IFFREE(colnames[i]);
 		}
 	}
 
@@ -3954,7 +3954,7 @@ CLEANUP:
 	{
 		EGLPNUM_TYPENAME_ILLlp_basis_free (B);
 	}
-	ILL_IFFREE (bname, char);
+	ILL_IFFREE(bname);
 
 	EG_RETURN (rval);
 }
@@ -4069,8 +4069,8 @@ CLEANUP:
 		EGioClose (out);
 	if (!B)
 	{
-		ILL_IFFREE (cstat, char);
-		ILL_IFFREE (rstat, char);
+		ILL_IFFREE(cstat);
+		ILL_IFFREE(rstat);
 	}
 	EG_RETURN (rval);
 }
@@ -4358,7 +4358,7 @@ static int test_matrix (
 
 CLEANUP:
 
-	ILL_IFFREE (tempi, int);
+	ILL_IFFREE(tempi);
 
 	EG_RETURN (rval);
 }

--- a/qsopt_ex/lp.c
+++ b/qsopt_ex/lp.c
@@ -283,7 +283,7 @@ CLEANUP:
 	ILLfree_names (colnames, lp->nstruct);
 	ILLfree_names (rownames, lp->nrows + 1);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (colCoef);
-	ILL_IFFREE (colInRow, int);
+	ILL_IFFREE(colInRow);
 
 	EG_RETURN (rval);
 }
@@ -813,7 +813,7 @@ static int read_problem_name (
 		}
 		else
 		{
-			ILL_IFFREE (lp->name, char);
+			ILL_IFFREE(lp->name);
 
 			ILL_UTIL_STR (lp->name, state->field);
 			ILL_IFTRACE ("ProblemName: %s\n", state->field);

--- a/qsopt_ex/lpdata.c
+++ b/qsopt_ex/lpdata.c
@@ -279,7 +279,7 @@ EGLPNUM_TYPENAME_QSdata *EGLPNUM_TYPENAME_ILLread (
 
 	p = EGLPNUM_TYPENAME_QScreate_prob (fname, QS_MIN);
 	ILL_CHECKnull (p, NULL);
-	ILL_IFFREE (p->qslp->probname, char);
+	ILL_IFFREE(p->qslp->probname);
 
 	lp = p->qslp;
 
@@ -371,7 +371,7 @@ void EGLPNUM_TYPENAME_ILLlpdata_free (
 
 	if (lp)
 	{
-		ILL_IFFREE (lp->sense, char);
+		ILL_IFFREE(lp->sense);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->obj);
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->rhs);
@@ -382,40 +382,40 @@ void EGLPNUM_TYPENAME_ILLlpdata_free (
 		if (lp->rA)
 		{
 			EGLPNUM_TYPENAME_ILLlp_rows_clear (lp->rA);
-			ILL_IFFREE (lp->rA, EGLPNUM_TYPENAME_ILLlp_rows);
+			ILL_IFFREE(lp->rA);
 		}
-		ILL_IFFREE (lp->is_sos_mem, int);
-		ILL_IFFREE (lp->refrowname, char);
+		ILL_IFFREE(lp->is_sos_mem);
+		ILL_IFFREE(lp->refrowname);
 
 		EGLPNUM_TYPENAME_ILLmatrix_free (&lp->sos);
 		if (lp->colnames)
 		{
 			for (i = 0; i < lp->nstruct; i++)
 			{
-				ILL_IFFREE (lp->colnames[i], char);
+				ILL_IFFREE(lp->colnames[i]);
 			}
-			ILL_IFFREE (lp->colnames, char *);
+			ILL_IFFREE(lp->colnames);
 		}
 		ILLsymboltab_free (&lp->coltab);
 		if (lp->rownames)
 		{
 			for (i = 0; i < lp->nrows; i++)
 			{
-				ILL_IFFREE (lp->rownames[i], char);
+				ILL_IFFREE(lp->rownames[i]);
 			}
-			ILL_IFFREE (lp->rownames, char *);
+			ILL_IFFREE(lp->rownames);
 		}
 		ILLsymboltab_free (&lp->rowtab);
-		ILL_IFFREE (lp->objname, char);
-		ILL_IFFREE (lp->probname, char);
-		ILL_IFFREE (lp->intmarker, char);
-		ILL_IFFREE (lp->structmap, int);
-		ILL_IFFREE (lp->rowmap, int);
+		ILL_IFFREE(lp->objname);
+		ILL_IFFREE(lp->probname);
+		ILL_IFFREE(lp->intmarker);
+		ILL_IFFREE(lp->structmap);
+		ILL_IFFREE(lp->rowmap);
 
 		if (lp->sinfo)
 		{
 			EGLPNUM_TYPENAME_ILLlp_sinfo_free (lp->sinfo);
-			ILL_IFFREE (lp->sinfo, EGLPNUM_TYPENAME_ILLlp_sinfo);
+			ILL_IFFREE(lp->sinfo);
 		}
 		EGLPNUM_TYPENAME_ILLlpdata_init (lp);
 	}
@@ -440,8 +440,8 @@ void EGLPNUM_TYPENAME_ILLlp_basis_free (
 {
 	if (B)
 	{
-		ILL_IFFREE (B->cstat, char);
-		ILL_IFFREE (B->rstat, char);
+		ILL_IFFREE(B->cstat);
+		ILL_IFFREE(B->rstat);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (B->rownorms);
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (B->colnorms);
@@ -685,8 +685,8 @@ CLEANUP:
 	{
 		EGLPNUM_TYPENAME_ILLlp_rows_clear (lprows);
 	}
-	ILL_IFFREE (hit, char);
-	ILL_IFFREE (inv_structmap, int);
+	ILL_IFFREE(hit);
+	ILL_IFFREE(inv_structmap);
 
 	EG_RETURN (rval);
 }
@@ -696,9 +696,9 @@ void EGLPNUM_TYPENAME_ILLlp_rows_clear (
 {
 	if (lprows != NULL)
 	{
-		ILL_IFFREE (lprows->rowbeg, int);
-		ILL_IFFREE (lprows->rowcnt, int);
-		ILL_IFFREE (lprows->rowind, int);
+		ILL_IFFREE(lprows->rowbeg);
+		ILL_IFFREE(lprows->rowcnt);
+		ILL_IFFREE(lprows->rowind);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (lprows->rowval);
 	}

--- a/qsopt_ex/mps.c
+++ b/qsopt_ex/mps.c
@@ -1308,7 +1308,7 @@ CLEANUP:
 	}
 	if (objname != lp->objname)
 	{
-		ILL_IFFREE (objname, char);
+		ILL_IFFREE(objname);
 	}
 	ILL_RESULT (rval, "ILLlpdata_mpswrite");
 }

--- a/qsopt_ex/names.c
+++ b/qsopt_ex/names.c
@@ -45,9 +45,9 @@ void ILLfree_names (
 	{
 		for (i = 0; i < count; i++)
 		{
-			ILL_IFFREE (names[i], char);
+			ILL_IFFREE(names[i]);
 		}
-		ILL_IFFREE (names, char *);
+		ILL_IFFREE(names);
 	}
 }
 
@@ -92,7 +92,7 @@ CLEANUP:
 		}
 	}
 
-	ILL_IFFREE (buf, char);
+	ILL_IFFREE(buf);
 
 	if (rval)
 	{

--- a/qsopt_ex/presolve.c
+++ b/qsopt_ex/presolve.c
@@ -443,7 +443,7 @@ int EGLPNUM_TYPENAME_ILLlp_scale (
 	if (lp->rA)
 	{															/* Need to clear the row version of data */
 		EGLPNUM_TYPENAME_ILLlp_rows_clear (lp->rA);
-		ILL_IFFREE (lp->rA, EGLPNUM_TYPENAME_ILLlp_rows);
+		ILL_IFFREE(lp->rA);
 	}
 
 
@@ -502,13 +502,13 @@ CLEANUP:
 		if (pre)
 		{
 			EGLPNUM_TYPENAME_ILLlp_predata_free (pre);
-			ILL_IFFREE (pre, EGLPNUM_TYPENAME_ILLlp_predata);
+			ILL_IFFREE(pre);
 		}
 
 		if (info)
 		{
 			EGLPNUM_TYPENAME_ILLlp_sinfo_free (info);
-			ILL_IFFREE (info, EGLPNUM_TYPENAME_ILLlp_sinfo);
+			ILL_IFFREE(info);
 		}
 	}
 	else
@@ -1017,9 +1017,9 @@ CLEANUP:
 	{
 		EGLPNUM_TYPENAME_ILLlp_sinfo_free (info);
 	}
-	ILL_IFFREE (tdeg, int);
-	ILL_IFFREE (map, int);
-	ILL_IFFREE (buf, char);
+	ILL_IFFREE(tdeg);
+	ILL_IFFREE(map);
+	ILL_IFFREE(buf);
 
 	ILL_RETURN (rval, "grab_lp_info");
 }
@@ -1304,7 +1304,7 @@ static int singleton_rows (
 
 CLEANUP:
 
-	ILL_IFFREE (tdeg, int);
+	ILL_IFFREE(tdeg);
 
 	intptr_listfree (&G->intptrworld, list);
 	EGLPNUM_TYPENAME_EGlpNumClearVar (val);
@@ -1765,7 +1765,7 @@ DONE:
 
 CLEANUP:
 
-	ILL_IFFREE (s, int);
+	ILL_IFFREE(s);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f);
 	EGLPNUM_TYPENAME_EGlpNumClearVar (q);
@@ -1896,7 +1896,7 @@ DONE:
 
 CLEANUP:
 
-	ILL_IFFREE (s, int);
+	ILL_IFFREE(s);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (f);
 	EGLPNUM_TYPENAME_EGlpNumClearVar (q);
@@ -2016,9 +2016,9 @@ static int gather_dup_lists (
 
 CLEANUP:
 
-	ILL_IFFREE (cnt, int);
-	ILL_IFFREE (ind, int);
-	ILL_IFFREE (beg, int);
+	ILL_IFFREE(cnt);
+	ILL_IFFREE(ind);
+	ILL_IFFREE(beg);
 
 	ILL_RETURN (rval, "gather_dup_lists");
 }
@@ -2423,10 +2423,10 @@ static void free_graph (
 
 		for (i = G->nzcount; i--;)
 			EGLPNUM_TYPENAME_EGlpNumClearVar ((G->edgelist[i].coef));
-		ILL_IFFREE (G->edgelist, edge);
-		ILL_IFFREE (G->rows, node);
-		ILL_IFFREE (G->cols, node);
-		ILL_IFFREE (G->adjspace, edge *);
+		ILL_IFFREE(G->edgelist);
+		ILL_IFFREE(G->rows);
+		ILL_IFFREE(G->cols);
+		ILL_IFFREE(G->adjspace);
 		if (intptr_check_leaks (&G->intptrworld, &total, &onlist))
 		{
 			QSlog("WARNING: %d outstanding intptrs", total - onlist);
@@ -2485,7 +2485,7 @@ int EGLPNUM_TYPENAME_ILLlp_sinfo_print (
 
 CLEANUP:
 
-	ILL_IFFREE (sense, char);
+	ILL_IFFREE(sense);
 
 	ILL_RETURN (rval, "EGLPNUM_TYPENAME_ILLlp_sinfo_print");
 }
@@ -2526,9 +2526,9 @@ void EGLPNUM_TYPENAME_ILLlp_sinfo_free (
 
 			for (i = 0; i < sinfo->ncols; i++)
 			{
-				ILL_IFFREE (sinfo->colnames[i], char);
+				ILL_IFFREE(sinfo->colnames[i]);
 			}
-			ILL_IFFREE (sinfo->colnames, char *);
+			ILL_IFFREE(sinfo->colnames);
 		}
 		EGLPNUM_TYPENAME_ILLlp_sinfo_init (sinfo);
 	}
@@ -2564,14 +2564,14 @@ void EGLPNUM_TYPENAME_ILLlp_predata_free (
 		{
 			EGLPNUM_TYPENAME_ILLlp_preop_free (&pre->oplist[i]);
 		}
-		ILL_IFFREE (pre->oplist, EGLPNUM_TYPENAME_ILLlp_preop);
-		ILL_IFFREE (pre->colmap, int);
-		ILL_IFFREE (pre->rowmap, int);
+		ILL_IFFREE(pre->oplist);
+		ILL_IFFREE(pre->colmap);
+		ILL_IFFREE(pre->rowmap);
 
-		ILL_IFFREE (pre->colscale, EGLPNUM_TYPE);
-		ILL_IFFREE (pre->rowscale, EGLPNUM_TYPE);
-		ILL_IFFREE (pre->colfixval, EGLPNUM_TYPE);
-		ILL_IFFREE (pre->rowfixval, EGLPNUM_TYPE);
+		ILL_IFFREE(pre->colscale);
+		ILL_IFFREE(pre->rowscale);
+		ILL_IFFREE(pre->colfixval);
+		ILL_IFFREE(pre->rowfixval);
 		EGLPNUM_TYPENAME_ILLlp_predata_init (pre);
 	}
 }
@@ -2626,7 +2626,7 @@ void EGLPNUM_TYPENAME_ILLlp_preline_free (
 		EGLPNUM_TYPENAME_EGlpNumClearVar (line->obj);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (line->upper);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (line->lower);
-		ILL_IFFREE (line->ind, int);
+		ILL_IFFREE(line->ind);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (line->val);
 		//EGLPNUM_TYPENAME_ILLlp_preline_init (line);

--- a/qsopt_ex/price.c
+++ b/qsopt_ex/price.c
@@ -182,10 +182,10 @@ void EGLPNUM_TYPENAME_ILLprice_free_pricing_info (
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (pinf->p_scaleinf);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (pinf->d_scaleinf);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (pinf->pdinfo.norms);
-	ILL_IFFREE (pinf->pdinfo.refframe, int);
+	ILL_IFFREE(pinf->pdinfo.refframe);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (pinf->psinfo.norms);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (pinf->ddinfo.norms);
-	ILL_IFFREE (pinf->ddinfo.refframe, int);
+	ILL_IFFREE(pinf->ddinfo.refframe);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (pinf->dsinfo.norms);
 
 	EGLPNUM_TYPENAME_ILLprice_free_mpartial_info (&(pinf->pmpinfo));
@@ -369,12 +369,12 @@ int EGLPNUM_TYPENAME_ILLprice_get_price (
 void EGLPNUM_TYPENAME_ILLprice_free_mpartial_info (
 	EGLPNUM_TYPENAME_mpart_info * p)
 {
-	ILL_IFFREE (p->gstart, int);
-	ILL_IFFREE (p->gshift, int);
-	ILL_IFFREE (p->gsize, int);
-	ILL_IFFREE (p->bucket, int);
+	ILL_IFFREE(p->gstart);
+	ILL_IFFREE(p->gshift);
+	ILL_IFFREE(p->gsize);
+	ILL_IFFREE(p->bucket);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (p->infeas);
-	ILL_IFFREE (p->perm, int);
+	ILL_IFFREE(p->perm);
 }
 
 int EGLPNUM_TYPENAME_ILLprice_build_mpartial_info (
@@ -689,7 +689,7 @@ CLEANUP:
 	if (rval)
 	{
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (pdinfo->norms);
-		ILL_IFFREE (pdinfo->refframe, int);
+		ILL_IFFREE(pdinfo->refframe);
 	}
 	EG_RETURN(rval);
 }
@@ -878,7 +878,7 @@ CLEANUP:
 	if (rval)
 	{
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (ddinfo->norms);
-		ILL_IFFREE (ddinfo->refframe, int);
+		ILL_IFFREE(ddinfo->refframe);
 	}
 	EG_RETURN(rval);
 }

--- a/qsopt_ex/priority.c
+++ b/qsopt_ex/priority.c
@@ -130,7 +130,7 @@ CLEANUP:
 
 	if (rval)
 	{
-		ILL_IFFREE (pri->pri_info, union EGLPNUM_TYPENAME_ILLpri_data);
+		ILL_IFFREE(pri->pri_info);
 	}
 	return rval;
 }
@@ -139,7 +139,7 @@ void EGLPNUM_TYPENAME_ILLutil_priority_free (
 	EGLPNUM_TYPENAME_ILLpriority * pri)
 {
 	EGLPNUM_TYPENAME_ILLutil_dheap_free (&pri->EGLPNUM_TYPENAME_heap);
-	ILL_IFFREE (pri->pri_info, union EGLPNUM_TYPENAME_ILLpri_data);
+	ILL_IFFREE(pri->pri_info);
 
 	pri->space = 0;
 }

--- a/qsopt_ex/qsopt.c
+++ b/qsopt_ex/qsopt.c
@@ -320,7 +320,7 @@ static int opt_work (
 		if (p->basis)
 		{
 			EGLPNUM_TYPENAME_ILLlp_basis_free (p->basis);
-			ILL_IFFREE (p->basis, EGLPNUM_TYPENAME_ILLlp_basis);
+			ILL_IFFREE(p->basis);
 		}
 		p->basis = p2->basis;
 		p2->basis = 0;
@@ -1125,7 +1125,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSdelete_rows (
 	if (p->basis && !basis_ok)
 	{
 		EGLPNUM_TYPENAME_ILLlp_basis_free (p->basis);
-		ILL_IFFREE (p->basis, EGLPNUM_TYPENAME_ILLlp_basis);
+		ILL_IFFREE(p->basis);
 	}
 
 	p->factorok = 0;
@@ -1199,7 +1199,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSdelete_setrows (
 
 CLEANUP:
 
-	ILL_IFFREE (dellist, int);
+	ILL_IFFREE(dellist);
 
 	EG_RETURN (rval);
 }
@@ -1256,7 +1256,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSdelete_named_rows_list (
 
 CLEANUP:
 
-	ILL_IFFREE (vdellist, int);
+	ILL_IFFREE(vdellist);
 
 	EG_RETURN (rval);
 }
@@ -1280,7 +1280,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSdelete_cols (
 	if (p->basis && !basis_ok)
 	{
 		EGLPNUM_TYPENAME_ILLlp_basis_free (p->basis);
-		ILL_IFFREE (p->basis, EGLPNUM_TYPENAME_ILLlp_basis);
+		ILL_IFFREE(p->basis);
 	}
 
 	p->factorok = 0;
@@ -1349,7 +1349,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSdelete_setcols (
 
 CLEANUP:
 
-	ILL_IFFREE (dellist, int);
+	ILL_IFFREE(dellist);
 
 	EG_RETURN (rval);
 }
@@ -1406,7 +1406,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSdelete_named_columns_lis
 
 CLEANUP:
 
-	ILL_IFFREE (vdellist, int);
+	ILL_IFFREE(vdellist);
 
 	EG_RETURN (rval);
 }
@@ -2054,7 +2054,7 @@ int grab_basis (
 
 	if (nstruct != B->nstruct)
 	{
-		ILL_IFFREE (B->cstat, char);
+		ILL_IFFREE(B->cstat);
 		ILL_SAFE_MALLOC (B->cstat, nstruct, char);
 
 		B->nstruct = nstruct;
@@ -2062,7 +2062,7 @@ int grab_basis (
 
 	if (nrows != B->nrows)
 	{
-		ILL_IFFREE (B->rstat, char);
+		ILL_IFFREE(B->rstat);
 		ILL_SAFE_MALLOC (B->rstat, nrows, char);
 
 		B->nrows = nrows;
@@ -2095,7 +2095,7 @@ CLEANUP:
 		if (B)
 		{
 			EGLPNUM_TYPENAME_ILLlp_basis_free (B);
-			ILL_IFFREE (p->basis, EGLPNUM_TYPENAME_ILLlp_basis);
+			ILL_IFFREE(p->basis);
 		}
 	}
 
@@ -2168,7 +2168,7 @@ CLEANUP:
 		{
 			EGLPNUM_TYPENAME_ILLlp_cache_free (C);
 			EGLPNUM_TYPENAME_EGlpNumClearVar (p->cache->val);
-			ILL_IFFREE (p->cache, EGLPNUM_TYPENAME_ILLlp_cache);
+			ILL_IFFREE(p->cache);
 		}
 	}
 
@@ -2182,7 +2182,7 @@ void free_cache (
 	{
 		EGLPNUM_TYPENAME_ILLlp_cache_free (p->cache);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (p->cache->val);
-		ILL_IFFREE (p->cache, EGLPNUM_TYPENAME_ILLlp_cache);
+		ILL_IFFREE(p->cache);
 	}
 	p->qstatus = QS_LP_MODIFIED;
 }
@@ -2310,7 +2310,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE void EGLPNUM_TYPENAME_QSfree_prob (
 		if (p->qslp)
 		{
 			EGLPNUM_TYPENAME_ILLlpdata_free (p->qslp);
-			ILL_IFFREE (p->qslp, EGLPNUM_TYPENAME_ILLlpdata);
+			ILL_IFFREE(p->qslp);
 		}
 		if (p->lp)
 		{
@@ -2325,28 +2325,28 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE void EGLPNUM_TYPENAME_QSfree_prob (
 			EGLPNUM_TYPENAME_EGlpNumClearVar (p->lp->upd.dty);
 			EGLPNUM_TYPENAME_EGlpNumClearVar (p->lp->upd.c_obj);
 			EGLPNUM_TYPENAME_EGlpNumClearVar (p->lp->upd.tz);
-			ILL_IFFREE (p->lp, EGLPNUM_TYPENAME_lpinfo);
+			ILL_IFFREE(p->lp);
 		}
 		if (p->basis)
 		{
 			EGLPNUM_TYPENAME_ILLlp_basis_free (p->basis);
-			ILL_IFFREE (p->basis, EGLPNUM_TYPENAME_ILLlp_basis);
+			ILL_IFFREE(p->basis);
 		}
 		if (p->cache)
 		{
 			EGLPNUM_TYPENAME_ILLlp_cache_free (p->cache);
 			EGLPNUM_TYPENAME_EGlpNumClearVar (p->cache->val);
-			ILL_IFFREE (p->cache, EGLPNUM_TYPENAME_ILLlp_cache);
+			ILL_IFFREE(p->cache);
 		}
 		if (p->pricing)
 		{
 			EGLPNUM_TYPENAME_EGlpNumClearVar (p->pricing->htrigger);
 			EGLPNUM_TYPENAME_ILLprice_free_pricing_info (p->pricing);
-			ILL_IFFREE (p->pricing, EGLPNUM_TYPENAME_price_info);
+			ILL_IFFREE(p->pricing);
 		}
-		ILL_IFFREE (p->name, char);
+		ILL_IFFREE(p->name);
 
-		ILL_IFFREE (p, EGLPNUM_TYPENAME_QSdata);
+		ILL_IFFREE(p);
 	}
 }
 
@@ -2355,10 +2355,10 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE void EGLPNUM_TYPENAME_QSfree_basis (
 {
 	if (B)
 	{
-		ILL_IFFREE (B->rstat, char);
-		ILL_IFFREE (B->cstat, char);
+		ILL_IFFREE(B->rstat);
+		ILL_IFFREE(B->cstat);
 
-		ILL_IFFREE (B, QSbasis);
+		ILL_IFFREE(B);
 	}
 }
 
@@ -2889,7 +2889,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSget_ranged_rows (
 
 CLEANUP:
 
-	ILL_IFFREE (rowlist, int);
+	ILL_IFFREE(rowlist);
 
 	EG_RETURN (rval);
 }
@@ -2985,7 +2985,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSget_rows (
 
 CLEANUP:
 
-	ILL_IFFREE (rowlist, int);
+	ILL_IFFREE(rowlist);
 
 	EG_RETURN (rval);
 }
@@ -3063,7 +3063,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSget_columns (
 
 CLEANUP:
 
-	ILL_IFFREE (collist, int);
+	ILL_IFFREE(collist);
 
 	EG_RETURN (rval);
 }
@@ -3246,7 +3246,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSget_intcount (
 CLEANUP:
 
 	*count = cnt;
-	ILL_IFFREE (intflags, int);
+	ILL_IFFREE(intflags);
 
 	EG_RETURN (rval);
 }
@@ -3354,7 +3354,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSwrite_prob_file (
 EGLPNUM_TYPENAME_QSLIB_INTERFACE void EGLPNUM_TYPENAME_QSfree (
 	void *ptr)
 {
-	ILL_IFFREE (ptr, void);
+	ILL_IFFREE(ptr);
 }
 
 EGLPNUM_TYPENAME_QSLIB_INTERFACE int EGLPNUM_TYPENAME_QSset_param (
@@ -3723,7 +3723,7 @@ EGLPNUM_TYPENAME_QSLIB_INTERFACE EGLPNUM_TYPENAME_QSdata *EGLPNUM_TYPENAME_QSget
 	ILL_CHECKnull (p, NULL);
 
 	ILL_FAILfalse (p->qslp != NULL, "If there's a p there must be a p-qslp");
-	ILL_IFFREE (p->name, char);
+	ILL_IFFREE(p->name);
 
 	ILL_UTIL_STR (p->name, p->qslp->probname);
 	EGLPNUM_TYPENAME_ILLsimplex_load_lpinfo (p->qslp, p->lp);

--- a/qsopt_ex/rawlp.c
+++ b/qsopt_ex/rawlp.c
@@ -162,14 +162,14 @@ void EGLPNUM_TYPENAME_ILLfree_rawlpdata (
 
 	if (lp)
 	{
-		ILL_IFFREE (lp->name, char);
+		ILL_IFFREE(lp->name);
 
 		ILLsymboltab_free (&lp->rowtab);
 		ILLsymboltab_free (&lp->coltab);
-		ILL_IFFREE (lp->rowsense, char);
+		ILL_IFFREE(lp->rowsense);
 
 		EGLPNUM_TYPENAME_ILLraw_clear_matrix (lp);
-		ILL_IFFREE (lp->cols, EGLPNUM_TYPENAME_colptr *);
+		ILL_IFFREE(lp->cols);
 		{
 			curr = lp->ranges;
 			while (curr)
@@ -186,26 +186,26 @@ void EGLPNUM_TYPENAME_ILLfree_rawlpdata (
 			QSlog("WARNING: %d outstanding colptrs", total - onlist);
 		}
 		ILLptrworld_delete (&lp->ptrworld);
-		ILL_IFFREE (lp->rhsname, char);
+		ILL_IFFREE(lp->rhsname);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->rhs);
-		ILL_IFFREE (lp->rhsind, char);
-		ILL_IFFREE (lp->rangesname, char);
-		ILL_IFFREE (lp->rangesind, char);
-		ILL_IFFREE (lp->boundsname, char);
-		ILL_IFFREE (lp->lbind, char);
-		ILL_IFFREE (lp->ubind, char);
+		ILL_IFFREE(lp->rhsind);
+		ILL_IFFREE(lp->rangesname);
+		ILL_IFFREE(lp->rangesind);
+		ILL_IFFREE(lp->boundsname);
+		ILL_IFFREE(lp->lbind);
+		ILL_IFFREE(lp->ubind);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->lower);
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->upper);
-		ILL_IFFREE (lp->intmarker, char);
-		ILL_IFFREE (lp->refrow, char);
-		ILL_IFFREE (lp->is_sos_member, int);
+		ILL_IFFREE(lp->intmarker);
+		ILL_IFFREE(lp->refrow);
+		ILL_IFFREE(lp->is_sos_member);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->sos_weight);
-		ILL_IFFREE (lp->sos_col, int);
+		ILL_IFFREE(lp->sos_col);
 
-		ILL_IFFREE (lp->sos_set, EGLPNUM_TYPENAME_sosptr);
+		ILL_IFFREE(lp->sos_set);
 		EGLPNUM_TYPENAME_ILLinit_rawlpdata (lp, NULL);
 	}
 }
@@ -591,7 +591,7 @@ static int ILLcheck_rawlpdata (
 
 	rval += ILLraw_check_bounds (lp);
 CLEANUP:
-	ILL_IFFREE (perm, int);
+	ILL_IFFREE(perm);
 
 	ILL_RESULT (rval, "ILLcheck_rawlpdata");
 }
@@ -926,7 +926,7 @@ static int whichColsAreUsed (
 		ILL_CLEANUP_IF (rval);
 	}
 CLEANUP:
-	ILL_IFFREE (colUsed, char);
+	ILL_IFFREE(colUsed);
 
 	ILL_RESULT (rval, "whichColsAreUsed");
 }
@@ -1002,7 +1002,7 @@ static int transferObjective (
 		}
 	}
 CLEANUP:
-	ILL_IFFREE (coefWarn, int);
+	ILL_IFFREE(coefWarn);
 
 	ILL_RETURN (rval, "transferObjective");
 }
@@ -1067,7 +1067,7 @@ static int transferColNamesLowerUpperIntMarker (
 	}
 	if (!hasIntVar)
 	{
-		ILL_IFFREE (lp->intmarker, char);
+		ILL_IFFREE(lp->intmarker);
 	}
 CLEANUP:
 	ILL_RETURN (rval, "transferColNamesLowerUpperIntMarker");
@@ -1261,9 +1261,9 @@ static int buildMatrix (
 	}
 	A->matind[lp->nzcount + nempty] = -1;
 CLEANUP:
-	ILL_IFFREE (nRowsUsed, int);
-	ILL_IFFREE (coefWarn, int);
-	ILL_IFFREE (coefSet, int);
+	ILL_IFFREE(nRowsUsed);
+	ILL_IFFREE(coefWarn);
+	ILL_IFFREE(coefSet);
 
 	ILL_RETURN (rval, "buildMatrix");
 }
@@ -1443,7 +1443,7 @@ static int convert_rawlpdata_to_lpdata (
 	ILL_FAILfalse (raw->objindex != -1, "EGLPNUM_TYPENAME_rawlpdata must have objective fct.");
 	EGLPNUM_TYPENAME_ILLlpdata_init (lp);
 
-	ILL_IFFREE (lp->probname, char);
+	ILL_IFFREE(lp->probname);
 
 	lp->probname = raw->name;
 	raw->name = 0;
@@ -1497,8 +1497,8 @@ static int convert_rawlpdata_to_lpdata (
 
 CLEANUP:
 
-	ILL_IFFREE (rowindex, int);
-	ILL_IFFREE (colindex, int);
+	ILL_IFFREE(rowindex);
+	ILL_IFFREE(colindex);
 
 	EGLPNUM_TYPENAME_ILLfree_rawlpdata (raw);
 

--- a/qsopt_ex/readline.c
+++ b/qsopt_ex/readline.c
@@ -56,7 +56,7 @@ CLEANUP:
 void EGLPNUM_TYPENAME_ILLline_reader_free (
 	EGLPNUM_TYPENAME_qsline_reader * reader)
 {
-	ILL_IFFREE (reader, EGLPNUM_TYPENAME_qsline_reader);
+	ILL_IFFREE(reader);
 }
 
 /* #endif */

--- a/qsopt_ex/simplex.c
+++ b/qsopt_ex/simplex.c
@@ -253,9 +253,9 @@ void EGLPNUM_TYPENAME_free_internal_lpinfo (
 
 	if (lp->localrows)
 	{
-		ILL_IFFREE (lp->rowcnt, int);
-		ILL_IFFREE (lp->rowbeg, int);
-		ILL_IFFREE (lp->rowind, int);
+		ILL_IFFREE(lp->rowcnt);
+		ILL_IFFREE(lp->rowbeg);
+		ILL_IFFREE(lp->rowind);
 
 		EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->rowval);
 		lp->localrows = 0;
@@ -270,8 +270,8 @@ void EGLPNUM_TYPENAME_free_internal_lpinfo (
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->pIdz);
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->pIxbz);
 
-	ILL_IFFREE (lp->vtype, int);
-	ILL_IFFREE (lp->vclass, char);
+	ILL_IFFREE(lp->vtype);
+	ILL_IFFREE(lp->vclass);
 
 	EGLPNUM_TYPENAME_ILLsvector_free (&(lp->zz));
 	EGLPNUM_TYPENAME_ILLsvector_free (&(lp->yjz));
@@ -279,14 +279,14 @@ void EGLPNUM_TYPENAME_free_internal_lpinfo (
 	EGLPNUM_TYPENAME_ILLsvector_free (&(lp->work));
 	EGLPNUM_TYPENAME_ILLsvector_free (&(lp->srhs));
 	EGLPNUM_TYPENAME_ILLsvector_free (&(lp->ssoln));
-	ILL_IFFREE (lp->iwork, int);
-	ILL_IFFREE (lp->upd.perm, int);
-	ILL_IFFREE (lp->upd.ix, int);
+	ILL_IFFREE(lp->iwork);
+	ILL_IFFREE(lp->upd.perm);
+	ILL_IFFREE(lp->upd.ix);
 
 	EGLPNUM_TYPENAME_EGlpNumFreeArray (lp->upd.t);
 
-	ILL_IFFREE (lp->bfeas, int);
-	ILL_IFFREE (lp->dfeas, int);
+	ILL_IFFREE(lp->bfeas);
+	ILL_IFFREE(lp->dfeas);
 
 	if (lp->tol)
 	{
@@ -296,14 +296,14 @@ void EGLPNUM_TYPENAME_free_internal_lpinfo (
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->tol->szero_tol);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->tol->ip_tol);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->tol->id_tol);
-		ILL_IFFREE (lp->tol, EGLPNUM_TYPENAME_tol_struct);
+		ILL_IFFREE(lp->tol);
 	}
 	if (lp->cnts)
 	{
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->cnts->y_ravg);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->cnts->z_ravg);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (lp->cnts->za_ravg);
-		ILL_IFFREE (lp->cnts, EGLPNUM_TYPENAME_count_struct);
+		ILL_IFFREE(lp->cnts);
 	}
 
 	while (lp->bchanges)
@@ -312,7 +312,7 @@ void EGLPNUM_TYPENAME_free_internal_lpinfo (
 		EGLPNUM_TYPENAME_EGlpNumClearVar (binfo->pbound);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (binfo->cbound);
 		lp->bchanges = binfo->next;
-		ILL_IFFREE (binfo, EGLPNUM_TYPENAME_bndinfo);
+		ILL_IFFREE(binfo);
 	}
 
 	while (lp->cchanges)
@@ -321,7 +321,7 @@ void EGLPNUM_TYPENAME_free_internal_lpinfo (
 		EGLPNUM_TYPENAME_EGlpNumClearVar (cinfo->pcoef);
 		EGLPNUM_TYPENAME_EGlpNumClearVar (cinfo->ccoef);
 		lp->cchanges = cinfo->next;
-		ILL_IFFREE (cinfo, EGLPNUM_TYPENAME_coefinfo);
+		ILL_IFFREE(cinfo);
 	}
 }
 
@@ -2873,7 +2873,7 @@ int EGLPNUM_TYPENAME_ILLsimplex_pivotin (
 	{
 		if (pivot_opt == SIMPLEX_PIVOTINROW)
 		{
-			ILL_IFFREE (clist, int);
+			ILL_IFFREE(clist);
 		}
 		EG_RETURN (rval);
 	}
@@ -2980,7 +2980,7 @@ int EGLPNUM_TYPENAME_ILLsimplex_pivotin (
 
 CLEANUP:
 	if (pivot_opt == SIMPLEX_PIVOTINROW)
-		ILL_IFFREE (clist, int);
+		ILL_IFFREE(clist);
 
 	EGLPNUM_TYPENAME_ILLsvector_free (&wz);
 	EGLPNUM_TYPENAME_ILLsvector_free (&updz);

--- a/qsopt_ex/symtab.c
+++ b/qsopt_ex/symtab.c
@@ -89,10 +89,10 @@ void ILLsymboltab_init (
 void ILLsymboltab_free (
 	ILLsymboltab * h)
 {
-	ILL_IFFREE (h->hashtable, int);
+	ILL_IFFREE(h->hashtable);
 
-	ILL_IFFREE (h->nametable, ILLsymbolent);
-	ILL_IFFREE (h->namelist, char);
+	ILL_IFFREE(h->nametable);
+	ILL_IFFREE(h->namelist);
 
 	ILLsymboltab_init (h);
 }
@@ -536,7 +536,7 @@ static int grow_symboltab (
 	newname = h->nametable;
 
 	ILL_SAFE_MALLOC (newhash, newhashspace, int);
-	ILL_IFFREE (h->hashtable, int);
+	ILL_IFFREE(h->hashtable);
 
 	h->hashtable = newhash;
 
@@ -590,7 +590,7 @@ static int grow_namelist (
 				h->nametable[i].symbol = newsymbol;
 			}
 		}
-		ILL_IFFREE (h->namelist, char);
+		ILL_IFFREE(h->namelist);
 
 		h->namelist = newnamelist;
 		h->strsize = newc - newnamelist;

--- a/tests/ftest.c
+++ b/tests/ftest.c
@@ -286,10 +286,10 @@ CLEANUP:
 		EGioClose (fin);
 	}
 	ILLfactor_free_factor_work (&f);
-	ILL_IFFREE (basis, int);
-	ILL_IFFREE (cbeg, int);
-	ILL_IFFREE (clen, int);
-	ILL_IFFREE (cind, int);
+	ILL_IFFREE(basis);
+	ILL_IFFREE(cbeg);
+	ILL_IFFREE(clen);
+	ILL_IFFREE(cind);
 
 	EGlpNumFreeArray (coef);
 	for (i = 0; i < niter; i++)


### PR DESCRIPTION
Remove unnecessary type parameter from `ILL_IFFREE`. Also removes redundant checks for NULL pointers since NULL pointers are guaranteed to be ignored by the final call to free().