### PR TITLE
commented out segfault causingcode

### DIFF
--- a/qsopt_ex/exact.c
+++ b/qsopt_ex/exact.c
@@ -718,11 +718,14 @@ int QSexact_optimal_test (mpq_QSdata * p,
 			rval = 0;
 			if(!msg_lvl)
 			{
+				/* removing this stops a segmentation fault that occurs on Mac OS. Needs further debugging to diagnose why this happens
+				
 				MESSAGE(0, "upper bound (%lg) variable (%lg) and dual variable"
 								" (%lg) don't satisfy complementary slacknes for variable "
 								"(%s,%d) %s", mpq_get_d(arr4[col]), 
 								mpq_get_d(p_sol[i+qslp->nstruct]), mpq_get_d(dz[col]), qslp->colnames[col], i,
 								"(real)");
+								*/
 			}
 			goto CLEANUP;
 		}


### PR DESCRIPTION
The message statement here causes a segmentation fault on Mac OS. This is a band aid for now til we can find the root cause. This helps address: https://github.com/jonls/python-qsoptex/issues/8